### PR TITLE
Remove delete message from custom command

### DIFF
--- a/commands/custom.py
+++ b/commands/custom.py
@@ -40,5 +40,4 @@ async def listcustom(ctx):
 async def c(ctx, arg):
     with open(os.environ["COMMANDS_DATA_FILE"]) as f:
         data = yaml.load(f, Loader=yaml.FullLoader)
-        await ctx.message.delete()
         await ctx.send(data[arg])


### PR DESCRIPTION
When the user sends an invalid custom command, like `.c foo` the user's message is deleted, and nothing is send, nothing happens, the user just get confused 🤔 

This PR is to keep the user's message, so he can know what the shit he sent and be happy 🚌 